### PR TITLE
Deploy Portfolio Project to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ npx stylelint "**/*.{css,scss}" npx hint ./index.html
 
 1. Open index.html located at the route folder of the project
 
+### Live Verion
 
+You find my project live at: <https://aeh1707.github.io/microverse-portfolio>
 
 ## Author
 


### PR DESCRIPTION
- Enabled the main portfolio project to go live GitHub Pages.
- Include the live URL in the README.md.